### PR TITLE
Add option to pass custom SSH port

### DIFF
--- a/gs-install.sh
+++ b/gs-install.sh
@@ -275,7 +275,7 @@ else
             echo -e "${STAT} Starting Gravity Sync Configuration"
 
         if [ ! -f /etc/gravity-sync/gravity-sync.conf ]; then 
-            /usr/local/bin/gravity-sync configure <&1
+            /usr/local/bin/gravity-sync configure $1 <&1
         else
             echo -e "${WARN} Existing gravity-sync.conf has been detected"
             echo -e "  Execute ${YELLOW}gravity-sync config${NC} to replace it"


### PR DESCRIPTION
Today one installs Gravity Sync with `curl -sSL https://gravity.vmstan.com | bash` which does not allow the installer to specify a custom SSH port so, one has to wait for the initial configuration wizard to fail and re-run `gravity-sync configure 2222`. 

`gs-install.sh` calls `/usr/local/bin/gravity-sync configure` after installation which allows for the option to pass along a custom SSH port. 

I propose adding the ability to pass a custom SSH port on initial install with this change. This allows for one to run the install with `curl -sSL https://gravity.vmstan.com | bash -s -- 2222` to set the custom SSH port for a successful initial install.

I am happy to submit a PR to update the Installation instructions to reflect this addition.